### PR TITLE
test: cover stt transcription and redis helpers

### DIFF
--- a/test/controller/core.test.ts
+++ b/test/controller/core.test.ts
@@ -1,10 +1,25 @@
-import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
 import { onMessageReceived, onCronJob } from '../../src/controller/core';
+import * as fs from 'fs';
 
 // Mock llm-proxy
 vi.mock('@derogab/llm-proxy', () => ({
   generate: vi.fn().mockResolvedValue({ content: 'Mocked summary response' }),
 }));
+
+// Mock stt-proxy
+vi.mock('@derogab/stt-proxy', () => ({
+  transcribe: vi.fn().mockResolvedValue({ text: 'Mocked transcription' }),
+}));
+
+// Mock fs
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+  };
+});
 
 // Mock data utils
 vi.mock('../../src/utils/data', async () => {
@@ -26,6 +41,7 @@ vi.mock('../../src/utils/data', async () => {
 import Storage from '../../src/utils/data';
 import * as dataUtils from '../../src/utils/data';
 import { generate } from '@derogab/llm-proxy';
+import { transcribe } from '@derogab/stt-proxy';
 
 describe('onMessageReceived', () => {
   let mockStorage: Storage;
@@ -35,6 +51,11 @@ describe('onMessageReceived', () => {
     vi.clearAllMocks();
     delete process.env.WHITELISTED_CHATS;
     delete process.env.MSG_LENGTH_LIMIT;
+    delete process.env.STT_PROVIDER;
+    delete process.env.WHISPER_CPP_MODEL_PATH;
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CLOUDFLARE_AUTH_KEY;
+    (fs.existsSync as Mock).mockReturnValue(false);
 
     mockStorage = new Storage();
     mockCtx = {
@@ -47,10 +68,17 @@ describe('onMessageReceived', () => {
         },
       },
       api: {
+        token: 'bot-token',
         sendChatAction: vi.fn().mockResolvedValue(undefined),
+        getFile: vi.fn().mockResolvedValue({ file_path: 'voice/file.ogg' }),
       },
       reply: vi.fn().mockResolvedValue(undefined),
     };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('should throw error when chatId is not available', async () => {
@@ -163,6 +191,65 @@ describe('onMessageReceived', () => {
     expect(dataUtils.updateHistory).toHaveBeenCalled();
     expect(generate).not.toHaveBeenCalled();
     expect(mockCtx.reply).not.toHaveBeenCalled();
+  });
+
+  it('should transcribe audio when Cloudflare STT is configured', async () => {
+    process.env.STT_PROVIDER = 'cloudflare';
+    process.env.CLOUDFLARE_ACCOUNT_ID = 'account-id';
+    process.env.CLOUDFLARE_AUTH_KEY = 'auth-key';
+    mockCtx.update.message.audio = { file_id: 'audio-file-id' };
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      arrayBuffer: vi.fn().mockResolvedValue(arrayBuffer),
+    }));
+
+    await onMessageReceived(mockStorage, mockCtx);
+
+    expect(mockCtx.api.getFile).toHaveBeenCalledWith('audio-file-id');
+    expect(fetch).toHaveBeenCalledWith('https://api.telegram.org/file/botbot-token/voice/file.ogg');
+    expect(transcribe).toHaveBeenCalledWith(expect.any(Buffer));
+    expect(mockCtx.reply).toHaveBeenCalledWith(
+      'Mocked transcription',
+      { reply_to_message_id: 1 }
+    );
+    expect(dataUtils.updateHistory).toHaveBeenCalledWith(
+      mockStorage,
+      'chat:123',
+      'testuser',
+      'Hello world\n\nMocked transcription'
+    );
+  });
+
+  it('should transcribe voice when whisper.cpp STT is configured', async () => {
+    process.env.STT_PROVIDER = 'whisper.cpp';
+    process.env.WHISPER_CPP_MODEL_PATH = '/tmp/whisper-model.bin';
+    (fs.existsSync as Mock).mockReturnValue(true);
+    mockCtx.update.message.text = undefined;
+    mockCtx.update.message.voice = { file_id: 'voice-file-id' };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6]).buffer),
+    }));
+
+    await onMessageReceived(mockStorage, mockCtx);
+
+    expect(mockCtx.api.getFile).toHaveBeenCalledWith('voice-file-id');
+    expect(dataUtils.updateHistory).toHaveBeenCalledWith(
+      mockStorage,
+      'chat:123',
+      'testuser',
+      'Mocked transcription'
+    );
+  });
+
+  it('should ignore audio when STT is not configured', async () => {
+    mockCtx.update.message.text = undefined;
+    mockCtx.update.message.voice = { file_id: 'voice-file-id' };
+
+    await onMessageReceived(mockStorage, mockCtx);
+
+    expect(mockCtx.api.getFile).not.toHaveBeenCalled();
+    expect(transcribe).not.toHaveBeenCalled();
+    expect(dataUtils.updateHistory).not.toHaveBeenCalled();
   });
 });
 

--- a/test/utils/data.test.ts
+++ b/test/utils/data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { generateKeyChat } from '../../src/utils/data';
 
 // Mock redis to prevent actual connections
@@ -18,6 +18,7 @@ vi.mock('redis', () => ({
   })),
 }));
 
+import { createClient } from 'redis';
 import Storage, { updateHistory, getHistory, getActiveChats } from '../../src/utils/data';
 
 describe('generateKeyChat', () => {
@@ -45,6 +46,10 @@ describe('Storage', () => {
     storage = new Storage();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('constructor', () => {
     it('should initialize with null client', () => {
       expect(storage.client).toBeNull();
@@ -62,6 +67,20 @@ describe('Storage', () => {
       const firstClient = storage.client;
       await storage.connect();
       expect(storage.client).toBe(firstClient);
+    });
+
+    it('should configure bounded Redis reconnect retries', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await storage.connect();
+      const createClientMock = vi.mocked(createClient);
+      const options = createClientMock.mock.calls[createClientMock.mock.calls.length - 1][0] as any;
+
+      expect(options.socket.reconnectStrategy(3)).toBe(300);
+      expect(options.socket.reconnectStrategy(11)).toBe(false);
+      expect(logSpy).toHaveBeenCalledWith('Redis connection retry 3/10');
+      expect(errorSpy).toHaveBeenCalledWith('Redis connection failed after 10 retries');
     });
   });
 
@@ -101,6 +120,23 @@ describe('getHistory', () => {
     const history = await getHistory(storage, 'chat:123');
     expect(Array.isArray(history)).toBe(true);
   });
+
+  it('should parse stored username and message entries', async () => {
+    const storage = new Storage();
+    storage.client = {
+      lRange: vi.fn().mockResolvedValue([
+        'alice###Hello world',
+        'bob###How are you?',
+      ]),
+    } as any;
+
+    const history = await getHistory(storage, 'chat:123');
+
+    expect(history).toEqual([
+      { username: 'alice', message: 'Hello world' },
+      { username: 'bob', message: 'How are you?' },
+    ]);
+  });
 });
 
 describe('getActiveChats', () => {
@@ -108,5 +144,19 @@ describe('getActiveChats', () => {
     const storage = new Storage();
     const chats = await getActiveChats(storage);
     expect(Array.isArray(chats)).toBe(true);
+  });
+
+  it('should remove the chat key prefix from active chat IDs', async () => {
+    const storage = new Storage();
+    storage.client = {
+      keys: vi.fn().mockResolvedValue([
+        'chat:123',
+        'chat:-100456',
+      ]),
+    } as any;
+
+    const chats = await getActiveChats(storage);
+
+    expect(chats).toEqual(['123', '-100456']);
   });
 });


### PR DESCRIPTION
## Summary
Adds coverage for STT transcription paths and Redis helper behavior so regressions in message handling and storage parsing are easier to catch.

## Changes
- Cover Cloudflare audio transcription, whisper.cpp voice transcription, and the no-STT fallback in message handling tests.
- Mock STT, file lookup, fetch, and filesystem checks needed for isolated transcription tests.
- Add Redis storage coverage for bounded reconnect retries, stored history parsing, and active chat ID extraction.

## Test plan
- [x] npm test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for STT transcription flows (Cloudflare, whisper.cpp, and no-STT fallback) and Redis helpers to prevent regressions in message handling and storage parsing. Tests mock fetch, filesystem, and STT to isolate behavior; verify audio/voice file retrieval and transcription updates; and check bounded Redis reconnect retries, stored history parsing, and active chat ID extraction.

<sup>Written for commit d52a6a2c678b7cbc5035244e3a626a5a7aaab66e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/derogab/summarygram/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

